### PR TITLE
Fix mutex IsLocked function for go >= 1.24

### DIFF
--- a/core/helpers/sync/mutex.go
+++ b/core/helpers/sync/mutex.go
@@ -1,7 +1,6 @@
 package sync
 
 import (
-	"reflect"
 	"sync"
 )
 
@@ -47,9 +46,4 @@ func (l *Mutex) Lock() {
 
 func (l *Mutex) Unlock() {
 	l.lock.Unlock()
-}
-
-func (l *Mutex) IsLocked() bool {
-	state := reflect.ValueOf(&l.lock).Elem().FieldByName("state")
-	return state.Int()&mutexLocked == mutexLocked
 }

--- a/core/helpers/sync/mutex_post124.go
+++ b/core/helpers/sync/mutex_post124.go
@@ -1,0 +1,13 @@
+//go:build go1.24
+
+package sync
+
+import (
+	"reflect"
+)
+
+func (l *Mutex) IsLocked() bool {
+	mu := reflect.ValueOf(&l.lock).Elem().FieldByName("mu")
+	state := mu.FieldByName("state")
+	return state.Int()&mutexLocked == mutexLocked
+}

--- a/core/helpers/sync/mutex_pre124.go
+++ b/core/helpers/sync/mutex_pre124.go
@@ -1,0 +1,12 @@
+//go:build !go1.24
+
+package sync
+
+import (
+	"reflect"
+)
+
+func (l *Mutex) IsLocked() bool {
+	state := reflect.ValueOf(&l.lock).Elem().FieldByName("state")
+	return state.Int()&mutexLocked == mutexLocked
+}

--- a/testing/mutex/test-is-locked/main.go
+++ b/testing/mutex/test-is-locked/main.go
@@ -1,0 +1,9 @@
+package main
+
+import "github.com/kyaxcorp/go-core/core/helpers/sync"
+
+var m sync.Mutex
+
+func main() {
+	m.TryLock()
+}


### PR DESCRIPTION
Since go 1.24, the sync.Mutex structure has been changed and no longer contains "state" field.

sync.Mutex contains "mu" field of type isync.Mutex, which already contains "state" field.

File mutex_post124.go implements new version of IsLocked function that reads "mu" field and then "state" field. This file only builds for go >= 1.24
File mutex_pre124.go contains old implementation of IsLocked function and only builds for go < 1.24